### PR TITLE
MACRO: setdlgposの位置指定方法のエンハンス #279 (TeraTermウインドウを基準とした位置の指定等 #234 関連)

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -43,6 +43,7 @@
       <li>Removed /LA command line options because language mode was removed.</li>
       <li>Changed method of creating backup files for TERATERM.INI.</li>
       <li>Updated Unicode information to Unicode 16.0. Before update, Unicode 15.1 compliant since Tera Term 5.0.</li>
+      <li>MACRO: <a href="../macro/command/setdlgpos.html">setdlgpos</a> Expanded the options for specifying the display position of the dialog box.</li>
     </ul>
   </li>
 

--- a/doc/en/html/macro/command/setdlgpos.html
+++ b/doc/en/html/macro/command/setdlgpos.html
@@ -18,18 +18,83 @@ Sets the position of dialog box.
 </p>
 
 <pre class="macro-syntax">
-setdlgpos [&lt;x&gt; &lt;y&gt;]
+setdlgpos [&lt;x&gt; &lt;y&gt; [&lt;position&gt; [&lt;offset x&gt; &lt;offset y&gt;]]]
 </pre>
+
+<h2>Parameters</h2>
+
+<dl>
+	<dt class="macro">integer &lt;x&gt;</dt>
+	<dd>X coordinate of the top-left corner of the dialog box.</dd>
+
+	<dt class="macro">integer &lt;y&gt;</dt>
+	<dd>Y coordinate of the top-left corner of the dialog box.</dd>
+
+	<dt class="macro">integer &lt;position&gt; (version 5.4 or later)</dt>
+	<dd>Display position of the dialog box.<br>
+	  1 : Top-left of the display.<br>
+	  2 : Top-right of the display.<br>
+	  3 : Bottom-left of the display.<br>
+	  4 : Bottom-right of the display.<br>
+	  5 : Center of the display.<br>
+	  6 : Top-left of the Tera Term VT window.<br>
+	  7 : Top-right of the Tera Term VT window.<br>
+	  8 : Bottom-left of the Tera Term VT window.<br>
+	  9 : Bottom-right of the Tera Term VT window.<br>
+	 10 : Center of the Tera Term VT window.<br>
+	</dd>
+
+	<dt class="macro">integer &lt;offset x&gt; (version 5.4 or later)</dt>
+	<dd>X coordinate adjustment value for the display position specified by &lt;position&gt;.</dd>
+
+	<dt class="macro">integer &lt;offset y&gt; (version 5.4 or later)</dt>
+	<dd>Y coordinate adjustment value for the display position specified by &lt;position&gt;.</dd>
+</dl>
+
+<h2>Return Value</h2>
+
+<dl>
+	<dt class="macro">No return value.</dt>
+</dl>
 
 <h2>Remarks</h2>
 
 <p>
-  Changes the initial position for dialog boxes opened by the "<a href="inputbox.html">inputbox</a>", "<a href="listbox.html">listbox</a>", "<a href="messagebox.html">messagebox</a>", "<a href="passwordbox.html">passwordbox</a>", "<a href="statusbox.html">statusbox</a>", "<a href="yesnobox.html">yesnobox</a>" commands and error dialogbox. If the status dialog box is displayed, the "setdlgpos" command also moves the dialog box.<br>
-Set dialog box position to default in main(primary) display when no argument is given. (version 4.105 or later)<br>
-&lt;x&gt; and &lt;y&gt; specify the position (x,y) in the screen coordinate.<br>
-The origin (0,0) is upper left corner of the screen(primary display).<br>
-Move into display, if dialog box position is outside display. (version 4.105 or later)
+Change the display position of the dialog boxes and the error dialog shown by the <a href="inputbox.html">"inputbox"</a>, <a href="listbox.html">"listbox"</a>, <a href="messagebox.html">"messagebox"</a>, <a href="passwordbox.html">"passwordbox"</a>, <a href="statusbox.html">"statusbox"</a>, <a href="yesnobox.html">"yesnobox"</a>.<br>
+If the status dialog box is displayed, the setdlgpos command will move that dialog box.<br>
+If the dialog extends beyond the display, it will be moved within the display.<em>(version 4.105 or later)</em><br>
+The unit is pixels.<br>
 </p>
+
+<ol>
+  <li>setdlgpos <em>(version 4.105 or later)</em><br>
+    When the parameter is omitted, the display position will be centered on the main display (the primary display)."
+  </li>
+  <li>setdlgpos &lt;x&gt; &lt;y&gt;<br>
+    Specify the coordinates (x,y) of the top-left corner of the dialog box using &lt;x&gt; and &lt;y&gt;.<br>
+    The origin (0,0) is the top-left corner of the main display.
+  </li>
+  <li>setdlgpos &lt;x&gt; &lt;y&gt; &lt;position&gt; <em>(version 5.4 or later)</em>
+    <ul>
+      <li>If &lt;position&gt; is between 1 and 5,<br>
+        If the MACRO is linked with Tera Term, the dialog box will be shown on the display where the VT window is displayed.<br>
+        If the MACRO is not linked with Tera Term, the dialog box will be shown on the main display.<br>
+        The display position of the dialog box will be the location specified by &lt;position&gt;.
+      </li>
+      <li>If &lt;position&gt; is between 6 and 10,<br>
+        If the MACRO is linked with Tera Term, the dialog box will be shown on the display where the VT window is displayed.<br>
+        If the MACRO is linked with Tera Term, the display position will be the location specified by &lt;position&gt;.<br>
+        If the MACRO is not linked with Tera Term or if Tera Term is minimized or hidden, the dialog box will be shown on the main display. <br>
+        In this case, the display position will be the &lt;x&gt; &lt;y&gt; coordinates.
+      </li>
+    </ul>
+  </li>
+  <li>setdlgpos &lt;x&gt; &lt;y&gt; &lt;position&gt; &lt;offset x&gt; &lt;offset y&gt; <em>(version 5.4 or later)</em><br>
+    The display position of the dialog box will be the location obtained by adding &lt;offset x&gt; &lt;offset y&gt; to the display position (x,y coordinates) specified by setdlgpos &lt;x&gt; &lt;y&gt; &lt;position&gt;.<br>
+    When specifying negative values, please refer to the <a href="../appendixes/negative.html">Note on negative integer constants</a>.
+
+  </li>
+</ol>
 
 <h2>Example</h2>
 
@@ -47,6 +112,54 @@ for i 0 200
   setdlgpos i 200
 next
 </pre>
+
+<pre class="macro-example">
+strdim message_string_array 11
+message_string_array[1]  = 'top-left of the display'
+message_string_array[2]  = 'top-right of the display'
+message_string_array[3]  = 'bottom-left of the display'
+message_string_array[4]  = 'bottom-right of the display'
+message_string_array[5]  = 'center of the display'
+message_string_array[6]  = 'top-left of the VT window'
+message_string_array[7]  = 'top-right of the VT window'
+message_string_array[8]  = 'bottom-left of the VT window'
+message_string_array[9]  = 'bottom-right of the VT window'
+message_string_array[10] = 'center of the VT window'
+
+strdim listbox_string_array 3
+listbox_string_array[0] = 'Banana'
+listbox_string_array[1] = 'Apple'
+listbox_string_array[2] = 'Orange'
+
+x = 0
+y = 0
+offset_x = 0
+offset_y = 0
+
+for position 1 10
+  sprintf2 message 'setdlgpos %d %d %d %d %d\n(%s)' x y position offset_x offset_y message_string_array[position]
+  strspecial message
+  setdlgpos x y position offset_x offset_y
+  statusbox   message 'statusbox'
+  messagebox  message 'messagebox'
+  yesnobox    message 'yesnobox'
+  inputbox    message 'inputbox'
+  passwordbox message 'passwordbox'
+  listbox     message 'listbox' listbox_string_array
+next
+</pre>
+
+<h2>See also</h2>
+<ul>
+  <li><a href="inputbox.html">inputbox</a></li>
+  <li><a href="listbox.html">listbox</a></li>
+  <li><a href="messagebox.html">messagebox</a></li>
+  <li><a href="passwordbox.html">passwordbox</a></li>
+  <li><a href="statusbox.html">statusbox</a></li>
+  <li><a href="yesnobox.html">yesnobox</a></li>
+  <li><a href="getttpos.html">getttpos</a></li>
+  <li><a href="../appendixes/negative.html">Note on negative integer constants</a></li>
+</ul>
 
 </body>
 </html>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -43,6 +43,7 @@
       <li>言語モードを削除したため /LA コマンドラインオプションを削除した。</li>
       <li>TERATERM.INI のバックアップファイルの作成方法を変更した。</li>
       <li>Unicode の文字情報を Unicode 16.0 に更新した。更新前、Tera Term 5.0 から Unicode 15.1 準拠だった。</li>
+      <li>MACRO: <a href="../macro/command/setdlgpos.html">setdlgpos</a> ダイアログボックスの表示位置をディスプレイ/VT ウインドウ相対で指定できるようにした。</li>
     </ul>
   </li>
 

--- a/doc/ja/html/macro/command/setdlgpos.html
+++ b/doc/ja/html/macro/command/setdlgpos.html
@@ -18,22 +18,82 @@
 </p>
 
 <pre class="macro-syntax">
-setdlgpos [&lt;x&gt; &lt;y&gt;]
+setdlgpos [&lt;x&gt; &lt;y&gt; [&lt;position&gt; [&lt;offset x&gt; &lt;offset y&gt;]]]
 </pre>
+
+<h2>パラメータ</h2>
+
+<dl>
+	<dt class="macro">整数 &lt;x&gt;</dt>
+	<dd>ダイアログボックス左上隅の X 座標。</dd>
+
+	<dt class="macro">整数 &lt;y&gt;</dt>
+	<dd>ダイアログボックス左上隅の Y 座標。</dd>
+
+	<dt class="macro">整数 &lt;position&gt; (バージョン 5.4 以降)</dt>
+	<dd>ダイアログボックスの表示位置。<br>
+	  1 : ディスプレイの左上<br>
+	  2 : ディスプレイの右上<br>
+	  3 : ディスプレイの左下<br>
+	  4 : ディスプレイの右下<br>
+	  5 : ディスプレイの中央<br>
+	  6 : Tera Term の VT ウインドウの左上<br>
+	  7 : Tera Term の VT ウインドウの右上<br>
+	  8 : Tera Term の VT ウインドウの左下<br>
+	  9 : Tera Term の VT ウインドウの右下<br>
+	 10 : Tera Term の VT ウインドウの中央
+	</dd>
+
+	<dt class="macro">整数 &lt;offset x&gt; (バージョン 5.4 以降)</dt>
+	<dd>&lt;position&gt; で指定した表示位置の X 座標補正値</dd>
+
+	<dt class="macro">整数 &lt;offset y&gt; (バージョン 5.4 以降)</dt>
+	<dd>&lt;position&gt; で指定した表示位置の Y 座標補正値</dd>
+</dl>
+
+<h2>返り値</h2>
+
+<dl>
+	<dt class="macro">無し</dt>
+</dl>
 
 <h2>解説</h2>
 
 <p>
-<a href="inputbox.html">"inputbox"</a>, <a href="listbox.html">"listbox"</a>, <a href="messagebox.html">"messagebox"</a>, <a href="passwordbox.html">"passwordbox"</a>, <a href="statusbox.html">"statusbox"</a>, <a href="yesnobox.html">"yesnobox"</a> コマンドで表示されるダイアログボックス、エラーダイアログ表示位置を位置を変更する。
-<br>
-また、ステータスダイアログボックスが表示されている場合、setdlgpos コマンドはそのダイアログボックスを移動させる。
-<br>
-パラメータ省略時、メインディスプレイ(プライマリディスプレイ)のデフォルトの表示位置となる (バージョン 4.105以降)。
-<br>
-&lt;x&gt; と &lt;y&gt; は画面の座標 (x,y) を表わす。原点 (0,0) はメインディスプレイの左上の隅の位置。
-<br>
-ダイアログがディスプレイからはみ出す場合は、ディスプレイ内に移動される (バージョン 4.105以降)。
+<a href="inputbox.html">"inputbox"</a>, <a href="listbox.html">"listbox"</a>, <a href="messagebox.html">"messagebox"</a>, <a href="passwordbox.html">"passwordbox"</a>, <a href="statusbox.html">"statusbox"</a>, <a href="yesnobox.html">"yesnobox"</a> コマンドで表示されるダイアログボックスとエラーダイアログの表示位置を変更する。<br>
+また、ステータスダイアログボックスが表示されている場合、setdlgpos コマンドはそのダイアログボックスを移動させる。<br>
+ダイアログがディスプレイからはみ出す場合は、ディスプレイ内に移動される。<em>(バージョン 4.105以降)</em><br>
+座標の単位はピクセル。<br>
 </p>
+
+<ol>
+  <li>setdlgpos <em>(バージョン 4.105以降)</em><br>
+    パラメータ省略時の表示位置は、メインディスプレイ(プライマリディスプレイ 以下略)の中央となる。
+  </li>
+  <li>setdlgpos &lt;x&gt; &lt;y&gt;<br>
+    &lt;x&gt; と &lt;y&gt; でダイアログボックス左上隅の座標 (x,y) を指定する。<br>
+    原点 (0,0)はメインディスプレイ左上隅。
+  </li>
+  <li>setdlgpos &lt;x&gt; &lt;y&gt; &lt;position&gt; <em>(バージョン 5.4 以降)</em>
+    <ul>
+      <li>&lt;position&gt; が 1 から 5 の場合<br>
+	MACRO が Tera Term とリンクされている場合は、VT ウインドウが表示されているディスプレイにダイアログボックスを表示する。<br>
+	MACRO が Tera Term とリンクされていない場合は、メインディスプレイにダイアログボックスを表示する。<br>
+	ダイアログボックスの表示位置は、&lt;position&gt; で指定した場所となる。
+      </li>
+      <li>&lt;position&gt; が 6 から 10 の場合<br>
+	MACRO が Tera Term とリンクされている場合は、VT ウインドウが表示されているディスプレイにダイアログボックスを表示する。<br>
+	MACRO が Tera Term とリンクされている場合の表示位置は、&lt;position&gt; で指定した場所となる。<br>
+	MACRO が Tera Term とリンクされていない、もしくは、Tera Term が最小化状態または非表示状態の場合は、メインディスプレイにダイアログボックスを表示する。<br>
+	この場合の表示位置は &lt;x&gt; &lt;y&gt; 座標となる。
+      </li>
+    </ul>
+  </li>
+  <li>setdlgpos &lt;x&gt; &lt;y&gt; &lt;position&gt; &lt;offset x&gt; &lt;offset y&gt; <em>(バージョン 5.4 以降)</em><br>
+    ダイアログボックスの表示位置は、setdlgpos &lt;x&gt; &lt;y&gt; &lt;position&gt; の表示位置(x,y座標)に &lt;offset x&gt; &lt;offset y&gt; を加算した場所となる。<br>
+    負の値を指定する場合は、<a href="../appendixes/negative.html">負の整数定数についての注意</a>を参照のこと。
+  </li>
+</ol>
 
 <h2>例</h2>
 
@@ -51,6 +111,54 @@ for i 0 200
   setdlgpos i 200
 next
 </pre>
+
+<pre class="macro-example">
+strdim message_string_array 11
+message_string_array[1]  = 'top-left of the display'
+message_string_array[2]  = 'top-right of the display'
+message_string_array[3]  = 'bottom-left of the display'
+message_string_array[4]  = 'bottom-right of the display'
+message_string_array[5]  = 'center of the display'
+message_string_array[6]  = 'top-left of the VT window'
+message_string_array[7]  = 'top-right of the VT window'
+message_string_array[8]  = 'bottom-left of the VT window'
+message_string_array[9]  = 'bottom-right of the VT window'
+message_string_array[10] = 'center of the VT window'
+
+strdim listbox_string_array 3
+listbox_string_array[0] = 'Banana'
+listbox_string_array[1] = 'Apple'
+listbox_string_array[2] = 'Orange'
+
+x = 0
+y = 0
+offset_x = 0
+offset_y = 0
+
+for position 1 10
+  sprintf2 message 'setdlgpos %d %d %d %d %d\n(%s)' x y position offset_x offset_y message_string_array[position]
+  strspecial message
+  setdlgpos x y position offset_x offset_y
+  statusbox   message 'statusbox'
+  messagebox  message 'messagebox'
+  yesnobox    message 'yesnobox'
+  inputbox    message 'inputbox'
+  passwordbox message 'passwordbox'
+  listbox     message 'listbox' listbox_string_array
+next
+</pre>
+
+<h2>参照</h2>
+<ul>
+  <li><a href="inputbox.html">inputbox</a></li>
+  <li><a href="listbox.html">listbox</a></li>
+  <li><a href="messagebox.html">messagebox</a></li>
+  <li><a href="passwordbox.html">passwordbox</a></li>
+  <li><a href="statusbox.html">statusbox</a></li>
+  <li><a href="yesnobox.html">yesnobox</a></li>
+  <li><a href="getttpos.html">getttpos</a></li>
+  <li><a href="../appendixes/negative.html">負の整数定数についての注意</a></li>
+</ul>
 
 </body>
 </html>

--- a/teraterm/common/ttlib.h
+++ b/teraterm/common/ttlib.h
@@ -154,6 +154,7 @@ BOOL GetPositionOnWindow(
 DllExport void GetMessageboxFont(LOGFONTA *logfont);
 void GetMessageboxFontW(LOGFONTW *logfont);
 void GetDesktopRect(HWND hWnd, RECT *rect);
+void GetDesktopRectFromPoint(const POINT *p, RECT *rect);
 void CenterWindow(HWND hWnd, HWND hWndParent);
 void MoveWindowToDisplay(HWND hWnd);
 void MoveWindowToDisplayPoint(HWND hWnd, const POINT *p);

--- a/teraterm/common/ttlib_static.c
+++ b/teraterm/common/ttlib_static.c
@@ -150,7 +150,7 @@ void GetDesktopRect(HWND hWnd, RECT *rect)
 /**
  *	pointが存在するディスプレイのデスクトップの範囲を取得する
  */
-static void GetDesktopRectFromPoint(const POINT *p, RECT *rect)
+void GetDesktopRectFromPoint(const POINT *p, RECT *rect)
 {
 	if (pMonitorFromPoint == NULL) {
 		// NT4.0, 95 はマルチモニタAPIに非対応

--- a/teraterm/ttpmacro/ListDlg.cpp
+++ b/teraterm/ttpmacro/ListDlg.cpp
@@ -242,7 +242,9 @@ void CListDlg::Relocation(BOOL is_init, int new_WW, int new_WH)
 	::MoveWindow(HCancel,CONTROL_GAP_W+CONTROL_GAP_W+LW,BH*2,BW,BH,TRUE);
 
 	if (is_init) {
-		SetDlgPos();
+		if (SetDlgPosEX(GetSafeHwnd(), WW, WH, &PosX, &PosY) < 0) {
+			SetDlgPos();
+		}
 	}
 
 	::InvalidateRect(m_hWnd, NULL, TRUE);
@@ -341,7 +343,9 @@ LRESULT CListDlg::DlgProc(UINT msg, WPARAM wp, LPARAM lp)
 
 			if (in_init) {
 				Relocation(FALSE, init_WW, init_WH);
-				SetDlgPos();
+				if (SetDlgPosEX(GetSafeHwnd(), WW, WH, &PosX, &PosY) < 0) {
+					SetDlgPos();
+				}
 			} else {
 				Relocation(FALSE, WW, WH);
 			}

--- a/teraterm/ttpmacro/errdlg.cpp
+++ b/teraterm/ttpmacro/errdlg.cpp
@@ -105,7 +105,9 @@ BOOL CErrDlg::OnInitDialog()
 	in_init = TRUE;
 	RECT R;
 	GetWindowRect(&R);
-	SetDlgPos();
+	if (SetDlgPosEX(m_hWnd, R.right - R.left, R.bottom - R.top, &PosX, &PosY) < 0) {
+		SetDlgPos();
+	}
 	::SetForegroundWindow(m_hWnd);
 	in_init = FALSE;
 
@@ -135,7 +137,9 @@ LRESULT CErrDlg::DlgProc(UINT msg, WPARAM wp, LPARAM lp)
 	case WM_DPICHANGED:
 		if (in_init == TRUE) {
 			RECT R = *(RECT *)lp;
-			SetDlgPos();
+			if (SetDlgPosEX(m_hWnd, R.right - R.left, R.bottom - R.top, &PosX, &PosY) < 0) {
+				SetDlgPos();
+			}
 		}
 		return TRUE;
 	}

--- a/teraterm/ttpmacro/inpdlg.cpp
+++ b/teraterm/ttpmacro/inpdlg.cpp
@@ -226,7 +226,9 @@ void CInpDlg::Relocation(BOOL is_init, int new_WW, int new_WH)
 	SendDlgItemMessage(IDC_INPEDIT, EM_LIMITTEXT, MaxStrLen, 0);
 
 	if (is_init) {
-		SetDlgPos();
+		if (SetDlgPosEX(GetSafeHwnd(), WW, WH, &PosX, &PosY) < 0) {
+			SetDlgPos();
+		}
 	}
 
 	InvalidateRect(NULL, TRUE);

--- a/teraterm/ttpmacro/msgdlg.cpp
+++ b/teraterm/ttpmacro/msgdlg.cpp
@@ -212,7 +212,9 @@ void CMsgDlg::Relocation(BOOL is_init, int new_WW, int new_WH)
 	}
 
 	if (is_init) {
-		SetDlgPos();
+		if (SetDlgPosEX(GetSafeHwnd(), WW, WH, &PosX, &PosY) < 0) {
+			SetDlgPos();
+		}
 	}
 
 	InvalidateRect(NULL);

--- a/teraterm/ttpmacro/statdlg.cpp
+++ b/teraterm/ttpmacro/statdlg.cpp
@@ -236,7 +236,9 @@ void CStatDlg::Relocation(BOOL is_init, int new_WW, int new_WH)
 	}
 
 	if (is_init) {
-		SetDlgPos();
+		if (SetDlgPosEX(GetSafeHwnd(), WW, WH, &PosX, &PosY) < 0) {
+			SetDlgPos();
+		}
 	}
 
 	InvalidateRect(NULL, TRUE);

--- a/teraterm/ttpmacro/ttl.cpp
+++ b/teraterm/ttpmacro/ttl.cpp
@@ -4208,14 +4208,26 @@ static WORD TTLSetDlgPos(void)
 		int x, y;
 		GetIntVal(&x,&Err);
 		GetIntVal(&y,&Err);
+		// 追加パラメータ(省略可能)
+		int position = 0, offset_x = 0, offset_y = 0;
+		if (CheckParameterGiven()) {
+			GetIntVal(&position,&Err);
+			if (position < 1 || position > 10) {
+				Err = ErrSyntax;
+			}
+			if (CheckParameterGiven()) {
+				GetIntVal(&offset_x,&Err);
+				GetIntVal(&offset_y,&Err);
+			}
+		}
 		if ((Err==0) && (GetFirstChar()!=0))
 			Err = ErrSyntax;
 		if (Err!=0) return Err;
-		SetDlgPos(x,y);
+		SetDlgPos(x, y, position, offset_x, offset_y);
 	}
 	else {
 		// パラメータがなければデフォルト位置に戻す
-		SetDlgPos(CW_USEDEFAULT, CW_USEDEFAULT);
+		SetDlgPos(CW_USEDEFAULT, CW_USEDEFAULT, 0, 0, 0);
 	}
 	return Err;
 }

--- a/teraterm/ttpmacro/ttmdlg.cpp
+++ b/teraterm/ttpmacro/ttmdlg.cpp
@@ -35,10 +35,12 @@
 #if !defined(_CRTDBG_MAP_ALLOC)
 #define _CRTDBG_MAP_ALLOC
 #endif
+#include <stdio.h>
 #include <stdlib.h>
 #include <crtdbg.h>
 #include <assert.h>
 
+#include "compat_win.h"
 #include "teraterm.h"
 #include "ttm_res.h"
 #include "ttlib.h"
@@ -51,6 +53,8 @@
 #include "ttmlib.h"
 #include "ttmdlg.h"
 #include "ttmacro.h"
+#include "ttmparse.h"
+#include "ttmdde.h"
 
 #include "ttmdlg.h"
 
@@ -66,6 +70,9 @@ BOOL SleepFlag;
 // (x,y) = (CW_USEDEFAULT, CW_USEDEFAULT)のときセンターに表示
 static int DlgPosX = CW_USEDEFAULT;
 static int DlgPosY = CW_USEDEFAULT;
+static int DlgPosition = 0;
+static int DlgOffsetX = 0;
+static int DlgOffsetY = 0;
 
 static CStatDlg *StatDlg = NULL;
 
@@ -170,13 +177,153 @@ BOOL GetFileName(HWND HWin, wchar_t **fname)
 	return TRUE;
 }
 
-void SetDlgPos(int x, int y)
+void SetDlgPos(int x, int y, int position, int offset_x, int offset_y)
 {
 	DlgPosX = x;
 	DlgPosY = y;
+	DlgPosition = position;
+	DlgOffsetX = offset_x;
+	DlgOffsetY = offset_y;
 	if (StatDlg!=NULL) { // update status box position
 		StatDlg->Update(NULL,NULL,DlgPosX,DlgPosY);
 	}
+}
+
+/*
+  SetDlgPosEX()
+
+   setdlgpos のパラメータ指定のうち、下記のNo.3と4を処理する。
+   No.1とNo.2は macrodlgbase.h の SetDlgPos() で処理する。
+
+   setdlgpos [<x> <y> [<position> [<offset x> <offset y>]]]
+   1. setdlgpos
+   2. setdlgpos <x> <y>
+   3. setdlgpos <x> <y> <position>
+   4. setdlgpos <x> <y> <position> <offset x> <offset y>
+
+*/
+int SetDlgPosEX(HWND hWnd, int width, int height, int *PosX, int *PosY) {
+	char Str[MaxStrLen];
+	int showflag;
+	int w_x, w_y, w_width, w_height;
+	int c_x, c_y, c_width, c_height;
+	RECT rcDesktop;
+	float vtwin_mag;
+	int new_x = 0, new_y = 0, new_width, new_height, position;
+	POINT pt;
+
+	if (hWnd == NULL || DlgPosition == 0) {
+		return -1;		// 固定位置
+	}
+
+	vtwin_mag = 1;
+	if (Linked) {
+		if (GetTTParam(CmdGetTTPos, Str, sizeof(Str)) != 0) {
+			return -1;
+		}
+		if (sscanf_s(Str, "%d %d %d %d %d %d %d %d %d", &showflag,
+					 &w_x, &w_y, &w_width, &w_height,
+					 &c_x, &c_y, &c_width, &c_height) != 9) {
+			return -1;
+		}
+
+		// Tera TermとMACROのメインウインドウの表示先ディスプレイが別でDPIが異なる場合の補正
+		if (DPIAware == DPI_AWARENESS_CONTEXT_UNAWARE) {
+			if (pMonitorFromRect != NULL && pGetDpiForMonitor != NULL) {
+				HMONITOR hMonitor;
+				RECT rc;
+				UINT dpi_x, dpi_y;
+				rc.left   = w_x;
+				rc.top    = w_y;
+				rc.right  = w_x + w_width;
+				rc.bottom = w_y + w_height;
+				hMonitor = pMonitorFromRect(&rc, MONITOR_DEFAULTTONEAREST);
+				if (hMonitor != NULL) {
+					pGetDpiForMonitor(hMonitor, (MONITOR_DPI_TYPE)0 /*0=MDT_EFFECTIVE_DPI*/, &dpi_x, &dpi_y);
+					vtwin_mag = ((float)GetMonitorDpiFromWindow(hWnd)) / dpi_x;
+				}
+			}
+		}
+	}
+
+	new_width  = (int)(width  * vtwin_mag);
+	new_height = (int)(height * vtwin_mag);
+
+	if (Linked && showflag != 1 && showflag != 3) {
+		pt.x = w_x + w_width  / 2;
+		pt.y = w_y + w_height / 2;
+	} else {
+		pt.x = 0;
+		pt.y = 0;
+	}
+	GetDesktopRectFromPoint(&pt, &rcDesktop);
+
+	if (DlgPosition >= 1 && DlgPosition <= 5) {					// ディスプレイ基準
+		c_x = rcDesktop.left;
+		c_y = rcDesktop.top;
+		c_width  = rcDesktop.right - rcDesktop.left;
+		c_height = rcDesktop.bottom - rcDesktop.top;
+		position = DlgPosition;
+	} else if (DlgPosition >= 6 && DlgPosition <= 10) {			// vt window基準
+		if (! Linked || showflag == 1 || showflag == 3) {
+			return -1; // 非リンク、1:最小化、3:非表示 の場合は固定位置
+		}
+		// DpiAware=offの場合の補正
+		if (DPIAware == DPI_AWARENESS_CONTEXT_UNAWARE) {
+			c_x 	 = (int)(c_x 	  * vtwin_mag);
+			c_y 	 = (int)(c_y 	  * vtwin_mag);
+			c_width  = (int)(c_width  * vtwin_mag);
+			c_height = (int)(c_height * vtwin_mag);
+		}
+		position = DlgPosition - 5;
+	} else {
+		return -1;
+	}
+
+	switch (position) {
+	case 1: // 左上隅
+		new_x = c_x;
+		new_y = c_y;
+		break;
+	case 2: // 右上隅
+		new_x = c_x + c_width - new_width;
+		new_y = c_y;
+		break;
+	case 3: // 左下隅
+		new_x = c_x;
+		new_y = c_y + c_height - new_height;
+		break;
+	case 4: // 右下隅
+		new_x = c_x + c_width  - new_width;
+		new_y = c_y + c_height - new_height;
+		break;
+	case 5: // 中央
+		new_x = c_x + c_width  / 2 - new_width  / 2;
+		new_y = c_y + c_height / 2 - new_height / 2;
+		break;
+	}
+	new_x += int(DlgOffsetX / vtwin_mag);
+	new_y += int(DlgOffsetY / vtwin_mag);
+
+	// デスクトップからはみ出さないよう調整
+	if (new_x + new_width > rcDesktop.right) {
+		new_x = rcDesktop.right - new_width;
+	}
+	if (new_x < rcDesktop.left){
+		new_x = rcDesktop.left;
+	}
+	if (new_y + new_height > rcDesktop.bottom) {
+		new_y = rcDesktop.bottom - new_height;
+	}
+	if (new_y < rcDesktop.top) {
+		new_y = rcDesktop.top;
+	}
+	*PosX = new_x;
+	*PosY = new_y;
+
+	SetWindowPos(hWnd, HWND_TOP, new_x, new_y, new_width, new_height, 0);
+
+	return 0;
 }
 
 int OpenInpDlg(wchar_t *Buff, const wchar_t *Text, const wchar_t *Caption,

--- a/teraterm/ttpmacro/ttmdlg.h
+++ b/teraterm/ttpmacro/ttmdlg.h
@@ -39,7 +39,8 @@ extern "C" {
 
 void ParseParam(PBOOL IOption, PBOOL VOption);
 BOOL GetFileName(HWND HWin, wchar_t **fname);
-void SetDlgPos(int x, int y);
+void SetDlgPos(int x, int y, int position, int offset_x, int offset_y);
+int SetDlgPosEX(HWND hWnd, int width, int height, int *PosX, int *PosY);
 int OpenInpDlg(wchar_t *Input, const wchar_t *Text, const wchar_t *Caption,
                 const wchar_t *Default, BOOL Paswd);
 int OpenErrDlg(const char *Msg, const char *Line, int lineno, int start, int end, const char *FileName);


### PR DESCRIPTION
#279 "TeraTermウインドウを基準とした位置の指定等が可能なよう、setdlgposによるダイアログの位置指定方法をエンハンスする"のPRになります。

>https://github.com/TeraTermProject/teraterm/issues/234 関連

>画面に整列した、複数のTeraTermのウインドウで、個々のマクロがポップアップを出しても
どれがどのポップアップなのか全然わからないので、
ポップアップ（messagebox 等）を出力する方法に画面基準ではなく、
自分のウインドウ基準でポップアップを出力する方法はありませんか？(setdlgpos)